### PR TITLE
Added rendering mode setting for component

### DIFF
--- a/Forte.React.AspNetCore/Forte.React.AspNetCore.csproj
+++ b/Forte.React.AspNetCore/Forte.React.AspNetCore.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <Packable>true</Packable>
-    <VersionPrefix>0.2.0.0</VersionPrefix>
+    <VersionPrefix>0.2.1.0</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Forte.React.AspNetCore/HtmlHelperExtensions.cs
+++ b/Forte.React.AspNetCore/HtmlHelperExtensions.cs
@@ -28,7 +28,7 @@ public static class HtmlHelperExtensions
     public static IHtmlString React<TComponent>(this HtmlHelper _, TComponent component) where TComponent : IReactComponent
     {
         var reactService = DependencyResolver.Current.GetService<IReactService>();
-        var renderedComponent = reactService.RenderToStringAsync(component.Path, null, component.ClientOnly).GetAwaiter().GetResult();
+        var renderedComponent = reactService.RenderToStringAsync(component.Path, null, component.RenderingMode).GetAwaiter().GetResult();
 
         return new HtmlString(renderedComponent);
     }
@@ -36,7 +36,7 @@ public static class HtmlHelperExtensions
     public static IHtmlString React<TComponent, TProps>(this HtmlHelper _, TComponent component) where TComponent : IReactComponent<TProps> where TProps : IReactComponentProps
     {
         var reactService = DependencyResolver.Current.GetService<IReactService>();
-        var renderedComponent = reactService.RenderToStringAsync(component.Path, component.Props, component.ClientOnly).GetAwaiter().GetResult();
+        var renderedComponent = reactService.RenderToStringAsync(component.Path, component.Props, component.RenderingMode).GetAwaiter().GetResult();
 
         return new HtmlString(renderedComponent);
     }
@@ -61,14 +61,14 @@ public static class HtmlHelperExtensions
     {
         var reactService = htmlHelper.ViewContext.HttpContext.RequestServices.GetRequiredService<IReactService>();
 
-        return new HtmlString(await reactService.RenderToStringAsync(component.Path, null, component.ClientOnly));
+        return new HtmlString(await reactService.RenderToStringAsync(component.Path, null, component.RenderingMode));
     }
     
     public static async Task<IHtmlContent> ReactAsync<TComponent, TProps>(this IHtmlHelper htmlHelper, TComponent component) where TComponent : IReactComponent<TProps> where TProps : IReactComponentProps
     {
         var reactService = htmlHelper.ViewContext.HttpContext.RequestServices.GetRequiredService<IReactService>();
 
-        return new HtmlString(await reactService.RenderToStringAsync(component.Path, component.Props, component.ClientOnly));
+        return new HtmlString(await reactService.RenderToStringAsync(component.Path, component.Props, component.RenderingMode));
     }
 
     public static IHtmlContent InitJavascript(this IHtmlHelper htmlHelper)

--- a/Forte.React.AspNetCore/React/Component.cs
+++ b/Forte.React.AspNetCore/React/Component.cs
@@ -8,13 +8,13 @@ internal class Component : IReactComponent
     public object? Props { get; }
     public string ContainerId { get; }
     public string JsonContainerId { get; }
-    public bool ClientOnly { get; }
+    public RenderingMode RenderingMode { get; }
 
-    public Component(string path, object? props = null, bool clientOnly = false)
+    public Component(string path, object? props = null, RenderingMode renderingMode = RenderingMode.ClientAndServer)
     {
         Path = path;
         Props = props;
-        ClientOnly = clientOnly;
+        RenderingMode = renderingMode;
         ContainerId = Guid.NewGuid().ToString("n").Substring(0, 8);
         JsonContainerId = ContainerId + "-json";
     }

--- a/Forte.React.AspNetCore/React/IReactComponent.cs
+++ b/Forte.React.AspNetCore/React/IReactComponent.cs
@@ -8,5 +8,5 @@ public interface IReactComponent<out TProps> : IReactComponent where TProps : IR
 public interface IReactComponent
 {
     string Path { get; }
-    bool ClientOnly { get; }
+    RenderingMode RenderingMode { get; }
 }

--- a/Forte.React.AspNetCore/React/RenderingMode.cs
+++ b/Forte.React.AspNetCore/React/RenderingMode.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace Forte.React.AspNetCore.React;
+
+[Flags]
+public enum RenderingMode
+{
+    /// <summary>
+    /// Component will only be rendered on the client.
+    /// </summary>
+    Client = 0,
+    
+    /// <summary>
+    /// Component will only be rendered as static markup on the server without hydration on the client.
+    /// </summary>
+    Server = 1,
+    
+    /// <summary>
+    /// Component will be rendered on the server and hydrated on the client.
+    /// </summary>
+    ClientAndServer = Client | Server,
+}


### PR DESCRIPTION
This PR adds a multi-state configuration property for the IReactComponent in place of previously introduced boolean property `ClientOnly`.

Now there is also an option to render component on the server only omitting hydration process on the client.

```
[Flags]
public enum RenderingMode
{
    /// <summary>
    /// Component will only be rendered on the client.
    /// </summary>
    Client = 0,
    
    /// <summary>
    /// Component will only be rendered as static markup on the server without hydration on the client.
    /// </summary>
    Server = 1,
    
    /// <summary>
    /// Component will be rendered on the server and hydrated on the client.
    /// </summary>
    ClientAndServer = Client | Server,
}
```

I bumped version to 0.2.1.0 because these changes do not affect public API (unless a custom implementation of IReactComponent is used, which I believe is only a case for NHO Project at the moment)